### PR TITLE
http package version update

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/VictorRancesCode/flutter_dialogflow
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.11.3+16
+  http: ^0.12.0+2
   googleapis_auth: ^0.2.6
 
 dev_dependencies:


### PR DESCRIPTION
http package version update.

Because every version of aad_oauth depends on http ^0.12.0 and flutter_dialogflow >=0.1.0 depends on http ^0.11.3+16, aad_oauth is incompatible with flutter_dialogflow >=0.1.0.
So, because my_mobile app depends on both flutter_dialogflow ^0.1.0 and aad_oauth ^0.1.7, version solving failed.
pub get failed (1)